### PR TITLE
Fix handling of cached line with leading formatting byte

### DIFF
--- a/spongemock.py
+++ b/spongemock.py
@@ -97,8 +97,8 @@ def spongemock(bot, trigger):
 
     if line:
         # last thing someone else said
-        nick, text = line.split(maxsplit=1)
-        bot.say(' '.join([nick, mock_case(text)]))
+        nick, sep, text = line.partition(' ')
+        bot.say(sep.join([nick, mock_case(text)]))
     else:
         # use given text
         bot.say(mock_case(trigger.group(2)))


### PR DESCRIPTION
It was either `partition(' ')` or use `split(' ', 1)`, and I don't use `partition` enough, so it won out.