### PR TITLE
Use unicodedata category to detect whitespace

### DIFF
--- a/spongemock.py
+++ b/spongemock.py
@@ -8,6 +8,7 @@ from __future__ import print_function, division, unicode_literals, absolute_impo
 
 import random
 import re
+import unicodedata
 
 from sopel import module, tools
 
@@ -113,8 +114,8 @@ def mock_case(text):
     repeat = 1
 
     for i in range(1, len(text)):
-        if text[i] == ' ':
-            # spaces shouldn't affect the case-repeat counting
+        if unicodedata.category(text[i]) == 'Zs':
+            # whitespace shouldn't affect the case-repeat counting
             out += text[i]
             continue
         if repeat == 2:


### PR DESCRIPTION
I knew I'd come up with a better method somewhere. Turns out I devised this method while building sopel-irc/sopel-rainbow.

This is related to #3, but not a "fix" or resolution, since it only worries about whitespace. That issue is concerned with skipping _any_ character that doesn't have "case" (e.g. punctuation).