### PR TITLE
Fix broken join() when smocking a known nick

### DIFF
--- a/sopel_spongemock/__init__.py
+++ b/sopel_spongemock/__init__.py
@@ -135,6 +135,6 @@ def spongemock(bot, trigger):
                 break
 
     if nick is not None:
-        text = sep.join(nick, text)
+        text = sep.join((nick, text))
 
     bot.say(text)


### PR DESCRIPTION
The current tip of development (observed in 1b4c2f5) has a bug that causes a TypeError when smocking a nick's previous message

> <[Q]> mic check
> <+SnoopJ> !smock [Q]
> <+terribot> Unexpected TypeError (str.join() takes exactly one argument (2 given)) from SnoopJ. Message was: !smock [Q]