### PR TITLE
Get the canonical nick in `get_cached_line()`

### DIFF
--- a/sopel_spongemock/__init__.py
+++ b/sopel_spongemock/__init__.py
@@ -100,7 +100,13 @@ def kick_prune(bot, trigger):
 
 def get_cached_line(bot, channel, nick):
     channel = tools.Identifier(channel)
-    nick = tools.Identifier(nick)
+
+    try:
+        nick = bot.users[nick].nick
+    except (KeyError, AttributeError):
+        # rather just leave `nick` as-is and continue outputting if possible
+        pass
+
     line = bot.memory['mock_lines'].get(channel, {}).get(nick, '')
     if line:
         return '<{}> {}'.format(nick, line)


### PR DESCRIPTION
Without the try/except, would be vulnerable to a race condition if the user being mocked leaves the network or is otherwise removed from `bot.users` before `get_cached_line()` is called.

We love threading.