### PR TITLE
Take advantage of Sopel 8 features when possible; fall back when not

### DIFF
--- a/sopel_spongemock/__init__.py
+++ b/sopel_spongemock/__init__.py
@@ -111,17 +111,20 @@ def kick_prune(bot, trigger):
 
 
 def get_cached_line(bot, channel, nick):
-    channel = tools.Identifier(channel)
+    if hasattr(bot, 'make_identifier'):
+        # sopel 8+
+        channel = bot.make_identifier(channel)
+        nick = bot.make_identifier(nick)
+    else:
+        # sopel 7
+        channel = tools.Identifier(channel)
+        nick = tools.Identifier(nick)
 
     try:
         nick = bot.users[nick].nick
     except (KeyError, AttributeError):
-        try:
-            # sopel 8+, with proper casemapping
-            nick = bot.make_identifier(nick)
-        except AttributeError:
-            # sopel 7 fallback
-            nick = tools.Identifier(nick)
+        # just keep what we already have; it's better than nothing
+        pass
 
     line = bot.memory['mock_lines'].get(channel, {}).get(nick, '')
     if line:

--- a/sopel_spongemock/__init__.py
+++ b/sopel_spongemock/__init__.py
@@ -104,8 +104,12 @@ def get_cached_line(bot, channel, nick):
     try:
         nick = bot.users[nick].nick
     except (KeyError, AttributeError):
-        # rather just leave `nick` as-is and continue outputting if possible
-        pass
+        try:
+            # sopel 8+, with proper casemapping
+            nick = bot.make_identifier(nick)
+        except AttributeError:
+            # sopel 7 fallback
+            nick = tools.Identifier(nick)
 
     line = bot.memory['mock_lines'].get(channel, {}).get(nick, '')
     if line:

--- a/sopel_spongemock/__init__.py
+++ b/sopel_spongemock/__init__.py
@@ -38,7 +38,13 @@ def setup(bot):
     bot.config.define_section('spongemock', SpongeMockSection)
 
     if 'mock_lines' not in bot.memory:
-        bot.memory['mock_lines'] = tools.SopelIdentifierMemory()
+        if hasattr(bot, 'make_identifier'):
+            # sopel 8+
+            new_mem = tools.SopelIdentifierMemory(identifier_factory=bot.make_identifier)
+        else:
+            # sopel 7
+            new_mem = tools.SopelIdentifierMemory()
+        bot.memory['mock_lines'] = new_mem
 
 
 def shutdown(bot):
@@ -55,7 +61,13 @@ def shutdown(bot):
 @plugin.unblockable
 def cache_lines(bot, trigger):
     if trigger.sender not in bot.memory['mock_lines']:
-        bot.memory['mock_lines'][trigger.sender] = tools.SopelIdentifierMemory()
+        if hasattr(bot, 'make_identifier'):
+            # sopel 8+
+            new_mem = tools.SopelIdentifierMemory(identifier_factory=bot.make_identifier)
+        else:
+            # sopel 7
+            new_mem = tools.SopelIdentifierMemory()
+        bot.memory['mock_lines'][trigger.sender] = new_mem
 
     line = trigger.group()
     # don't store /me commands, or obvious bot commands


### PR DESCRIPTION
8.0 isn't out just yet, so primary consumers of this plugin are still using code that won't always correctly `.get()` the value from a `SopelIdentifierMemory` when passing in a regular string key. But we still want to take advantage of the bot's `make_identifier()` method if it's available.