### PR TITLE
Prune old nick's cached line after nick-change

### DIFF
--- a/sopel_spongemock/__init__.py
+++ b/sopel_spongemock/__init__.py
@@ -77,10 +77,11 @@ def part_prune(bot, trigger):
 
 
 @plugin.echo
-@plugin.event('QUIT')
+@plugin.event('QUIT', 'NICK')
 @plugin.priority('low')
 @plugin.unblockable
 def quit_prune(bot, trigger):
+    # NICK is treated like the old nick QUITting for simplicity
     for channel in bot.memory['mock_lines'].keys():
         bot.memory['mock_lines'][channel].pop(trigger.nick, None)
 


### PR DESCRIPTION
It's either this or an interval job to scrub nicks who are no longer present in each channel from the memory every X seconds/minutes/hours.